### PR TITLE
Updated params

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# krb5/k5start
+
+
+## generate a cache file file only usable for the specifed user : 
+
+basicaly requires /home/vfoucault/vfoucault.keytab to be existant as long a the user
+
+```puppet
+krb5::k5start::initscript { 'vfoucault_k5start':
+  owner       => 'vfoucault',
+  keytab      => '/home/vfoucault/vfoucault.keytab',
+  use_selinux => false,
+  notify      => Service["k5start-vfoucault"],
+  require     => File['/home/vfoucault/vfoucault.keytab']
+}
+
+file { '/home/vfoucault/vfoucault.keytab':
+  ensure => present
+}
+
+service { 'k5start-vfoucault':
+  ensure => running,
+  require => File['/home/vfoucault/vfoucault.keytab']
+}
+```
+
+
+## other settings : 
+
+* ```use_selinux```: Can be ```true``` of ```false``` default to ```true``` : Do we have selinux enabled on the target systems ?
+* ```group```: a optional group name to replace the owner default group.
+* ```mode```: Set ticket cache permissions to <mode> (octal). default to 600.

--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@ service { 'k5start-vfoucault':
 * ```use_selinux```: Can be ```true``` of ```false``` default to ```true``` : Do we have selinux enabled on the target systems ?
 * ```group```: a optional group name to replace the owner default group.
 * ```mode```: Set ticket cache permissions to <mode> (octal). default to 600.
+* ```tkt_lifetime``` : Set the ticket cache lifetime. Cannot be greater than the max_lifetime kerberos setting. should be <int><unit>, lake "1d", "12h" and so on. 

--- a/manifests/k5start/initscript.pp
+++ b/manifests/k5start/initscript.pp
@@ -1,18 +1,17 @@
 define krb5::k5start::initscript (
-  $owner = undef,
-  $owner_uid = undef,
-  $minutes = undef,
-  $options = undef,
-  $keytab = undef
+  $owner       = undef,
+  $minutes     = 60,
+  $options     = undef,
+  $keytab      = undef,
+  $use_selinux = true,
 ) {
   include krb5::k5start
 
   $owner_r = $owner
-  $owner_uid_r = $owner_uid
   $minutes_r = $minutes
   $options_r = $options
   $keytab_r = $keytab
-  $name_r = $name
+  $name_r = $owner
 
   file { "/etc/init.d/k5start-${name_r}":
     ensure  => present,

--- a/manifests/k5start/initscript.pp
+++ b/manifests/k5start/initscript.pp
@@ -1,13 +1,16 @@
 define krb5::k5start::initscript (
   $owner       = undef,
+  $group       = undef,
   $minutes     = 60,
   $options     = undef,
   $keytab      = undef,
   $use_selinux = true,
+  $filemode    = '600',
 ) {
   include krb5::k5start
 
   $owner_r = $owner
+  $group_r = $group
   $minutes_r = $minutes
   $options_r = $options
   $keytab_r = $keytab

--- a/manifests/k5start/initscript.pp
+++ b/manifests/k5start/initscript.pp
@@ -6,15 +6,18 @@ define krb5::k5start::initscript (
   $keytab      = undef,
   $use_selinux = true,
   $filemode    = '600',
+  $tktlifetime = undef,
 ) {
   include krb5::k5start
 
-  $owner_r = $owner
-  $group_r = $group
-  $minutes_r = $minutes
-  $options_r = $options
-  $keytab_r = $keytab
-  $name_r = $owner
+  $owner_r       = $owner
+  $group_r       = $group
+  $minutes_r     = $minutes
+  $options_r     = $options
+  $keytab_r      = $keytab
+  $name_r        = $owner
+  $filemode_r    = $filemode
+  $tktlifetime_r = $tktlifetime
 
   file { "/etc/init.d/k5start-${name_r}":
     ensure  => present,

--- a/templates/k5start.init.erb
+++ b/templates/k5start.init.erb
@@ -8,7 +8,7 @@
 #
 # processname: /usr/bin/k5start
 # config: /etc/krb5.conf
-# pidfile: /var/run/k5start-<%= @owner %>.pid
+# pidfile: /var/run/k5start-<%= @owner_r%>.pid
 
 prog="/usr/bin/k5start"
 # Sanity checks.
@@ -35,22 +35,22 @@ FILEMODE=<%= @filemode_r %>
 RETVAL=0
 
 start() {
-    echo -n $"Starting k5start-<%= @owner %>: "
+    echo -n $"Starting k5start-<%= @owner_r%>: "
     # 20121012, skg - This will fail without runcon. See redhat bug 785925.
     daemon <% if @use_selinux -%>runcon -t unconfined_t <% end -%>$prog -k $KRB5CCNAME -f $K5START_KEYTAB -bLK $K5START_MINUTES \
                         -o $OWNER -g $GROUP -m $FILEMODE \
-                        -p /var/run/k5start-<%= @owner %>.pid $K5START_OPTIONS -U
+                        -p /var/run/k5start-<%= @owner_r%>.pid $K5START_OPTIONS -U
     RETVAL=$?
     echo
-    [ $RETVAL -eq 0 ] && touch /var/lock/subsys/k5start-<%= @owner %>
+    [ $RETVAL -eq 0 ] && touch /var/lock/subsys/k5start-<%= @owner_r%>
     return $RETVAL
 }
 
 stop() {
-    echo -n $"Stopping k5start-<%= @owner %>: "
-    killproc -p /var/run/k5start-<%= @owner %>.pid k5start-<% @owner %>
+    echo -n $"Stopping k5start-<%= @owner_r%>: "
+    killproc -p /var/run/k5start-<%= @owner_r%>.pid k5start-<% @owner_r%>
     RETVAL=$?
-    [ $RETVAL -eq 0 ] && rm -f /var/lock/subsys/k5start-<%= @owner %>
+    [ $RETVAL -eq 0 ] && rm -f /var/lock/subsys/k5start-<%= @owner_r%>
     echo
     return $RETVAL
 }
@@ -71,7 +71,7 @@ case "$1" in
         RETVAL=$?
         ;;
     status)
-        status -p /var/run/k5start-<%= @owner %>.pid k5start-<%= @owner %>
+        status -p /var/run/k5start-<%= @owner_r%>.pid k5start-<%= @owner_r%>
         RETVAL=$?
         ;;
     restart)
@@ -79,7 +79,7 @@ case "$1" in
         RETVAL=$?
         ;;
     try-restart | condrestart)
-        [ -e /var/lock/subsys/k5start-<%= @owner %> ] && restart
+        [ -e /var/lock/subsys/k5start-<%= @owner_r%> ] && restart
         RETVAL=$?
         ;;
     force-reload | reload)

--- a/templates/k5start.init.erb
+++ b/templates/k5start.init.erb
@@ -22,9 +22,10 @@ K5START_KEYTAB=<%= @keytab_r %>
 K5START_MINUTES=<%= @minutes_r %>
 K5START_OPTIONS=<%= @options_r %>
 OWNER=<%= @owner_r %>
-GROUP=$(/usr/bin/id -ng $OWNER)
+GROUP=<% if @group_r -%><%= @group_r %><% else -%>$(/usr/bin/id -ng $OWNER)<% end %>
 USERUID=$(/usr/bin/id -u $OWNER)
 KRB5CCNAME=/tmp/krb5cc_${USERUID}
+FILEMODE=<%= @filemode_r %>
 
 # Source an auxiliary options file if we have one
 # This can override K5START_KEYTAB, K5START_MINUTES and K5START_OPTIONS
@@ -37,7 +38,7 @@ start() {
     echo -n $"Starting k5start-<%= @owner %>: "
     # 20121012, skg - This will fail without runcon. See redhat bug 785925.
     daemon <% if @use_selinux -%>runcon -t unconfined_t <% end -%>$prog -k $KRB5CCNAME -f $K5START_KEYTAB -bLK $K5START_MINUTES \
-                        -o $OWNER -g $GROUP \
+                        -o $OWNER -g $GROUP -m $FILEMODE \
                         -p /var/run/k5start-<%= @owner %>.pid $K5START_OPTIONS -U
     RETVAL=$?
     echo

--- a/templates/k5start.init.erb
+++ b/templates/k5start.init.erb
@@ -38,7 +38,7 @@ start() {
     echo -n $"Starting k5start-<%= @owner_r%>: "
     # 20121012, skg - This will fail without runcon. See redhat bug 785925.
     daemon <% if @use_selinux -%>runcon -t unconfined_t <% end -%>$prog -k $KRB5CCNAME -f $K5START_KEYTAB -bLK $K5START_MINUTES \
-                        -o $OWNER -g $GROUP -m $FILEMODE \
+                        <% if @tktlifetime_r -%>-l <%= @tktlifetime_r -%><% end %> -o $OWNER -g $GROUP -m $FILEMODE \
                         -p /var/run/k5start-<%= @owner_r%>.pid $K5START_OPTIONS -U
     RETVAL=$?
     echo

--- a/templates/k5start.init.erb
+++ b/templates/k5start.init.erb
@@ -8,11 +8,12 @@
 #
 # processname: /usr/bin/k5start
 # config: /etc/krb5.conf
-# pidfile: /var/run/k5start-<%= @title %>.pid
+# pidfile: /var/run/k5start-<%= @owner %>.pid
 
+prog="/usr/bin/k5start"
 # Sanity checks.
 [ -f /etc/krb5.conf ] || exit 0
-[ -x /usr/bin/k5start ] || exit 0
+[ -x $prog ] || exit 0
 
 # Source function library.
 . /etc/init.d/functions
@@ -21,7 +22,9 @@ K5START_KEYTAB=<%= @keytab_r %>
 K5START_MINUTES=<%= @minutes_r %>
 K5START_OPTIONS=<%= @options_r %>
 OWNER=<%= @owner_r %>
-KRB5CCNAME=/tmp/krb5cc_<%= @owner_uid_r %>
+GROUP=$(/usr/bin/id -ng $OWNER)
+USERUID=$(/usr/bin/id -u $OWNER)
+KRB5CCNAME=/tmp/krb5cc_${USERUID}
 
 # Source an auxiliary options file if we have one
 # This can override K5START_KEYTAB, K5START_MINUTES and K5START_OPTIONS
@@ -30,24 +33,23 @@ KRB5CCNAME=/tmp/krb5cc_<%= @owner_uid_r %>
 
 RETVAL=0
 
-
 start() {
-    echo -n $"Starting k5start-<%= @title %>: "
+    echo -n $"Starting k5start-<%= @owner %>: "
     # 20121012, skg - This will fail without runcon. See redhat bug 785925.
-    daemon runcon -t unconfined_t /usr/bin/k5start -k $KRB5CCNAME -f $K5START_KEYTAB -bLK $K5START_MINUTES \
-                        -o $OWNER -g $OWNER \
-                        -p /var/run/k5start-<%= @title %>.pid $K5START_OPTIONS -U
+    daemon <% if @use_selinux -%>runcon -t unconfined_t <% end -%>$prog -k $KRB5CCNAME -f $K5START_KEYTAB -bLK $K5START_MINUTES \
+                        -o $OWNER -g $GROUP \
+                        -p /var/run/k5start-<%= @owner %>.pid $K5START_OPTIONS -U
     RETVAL=$?
     echo
-    [ $RETVAL -eq 0 ] && touch /var/lock/subsys/k5start-<%= @title %>
+    [ $RETVAL -eq 0 ] && touch /var/lock/subsys/k5start-<%= @owner %>
     return $RETVAL
 }
 
 stop() {
-    echo -n $"Stopping k5start-<%= @title %>: "
-    killproc -p /var/run/k5start-<%= @title %>.pid k5start-<% @title %>
+    echo -n $"Stopping k5start-<%= @owner %>: "
+    killproc -p /var/run/k5start-<%= @owner %>.pid k5start-<% @owner %>
     RETVAL=$?
-    [ $RETVAL -eq 0 ] && rm -f /var/lock/subsys/k5start-<%= @title %>
+    [ $RETVAL -eq 0 ] && rm -f /var/lock/subsys/k5start-<%= @owner %>
     echo
     return $RETVAL
 }
@@ -68,7 +70,7 @@ case "$1" in
         RETVAL=$?
         ;;
     status)
-        status -p /var/run/k5start-<%= @title %>.pid k5start-<%= @title %>
+        status -p /var/run/k5start-<%= @owner %>.pid k5start-<%= @owner %>
         RETVAL=$?
         ;;
     restart)
@@ -76,7 +78,7 @@ case "$1" in
         RETVAL=$?
         ;;
     try-restart | condrestart)
-        [ -e /var/lock/subsys/k5start-<%= @title %> ] && restart
+        [ -e /var/lock/subsys/k5start-<%= @owner %> ] && restart
         RETVAL=$?
         ;;
     force-reload | reload)


### PR DESCRIPTION
- added option `use_selinux` to disable chcon is selinux is not present or used
- get the owner uid from inside the init script. `USERUID=$(/usr/bin/id -u $OWNER)`
- get the owner primary gid from inside the init script `GROUP=$(/usr/bin/id -ng $OWNER)`
- updated the init script name (and the init script contents) to reflect not the resource name but the user name
- made the `minutes` a default value if not specified, to 60 minutes
- added the `group` to override the user primary group
- added the `filemode` to specify the ticket cache file mode.

``` puppet
krb5::k5start::initscript { 'vfoucault_k5start':
  owner       => 'vfoucault',
  keytab      => '/home/vfoucault/vfoucault.keytab',
  use_selinux => false,
  notify      => Service["k5start-vfoucault"],
  require     => File['/home/vfoucault/vfoucault.keytab']
}

file { '/home/vfoucault/vfoucault.keytab':
  ensure => present
}

service { 'k5start-vfoucault':
  ensure => running,
  require => File['/home/vfoucault/vfoucault.keytab']
}
```
